### PR TITLE
Update curve25519-dalek dependency to 1.2.3.

### DIFF
--- a/monero/Cargo.toml
+++ b/monero/Cargo.toml
@@ -21,7 +21,7 @@ wagyu-model = { path = "../model", version = "0.6.0" }
 
 base58-monero = { version = "0.1.1" }
 crc = { version = "1.8.1" }
-curve25519-dalek = { version = "1.2.1" }
+curve25519-dalek = { version = "1.2.3" }
 hex = { version = "0.3.2" }
 rand = { version = "0.7" }
 serde = { version = "1.0", features = ["derive"] }

--- a/zcash/Cargo.toml
+++ b/zcash/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = { version = "1.3.0" }
 bech32 = { version = "0.6" }
 base58 = { version = "0.1" }
 byteorder = { version = "1.1" }
-curve25519-dalek = { version = "1" }
+curve25519-dalek = { version = "1.2.3" }
 hex = { version = "0.3.2" }
 rand = { version = "0.7" }
 rand_core = { version = "0.5.0" }


### PR DESCRIPTION
The Scalar::from_bits function allows constructing unreduced scalars with
exactly the given bit pattern, for compatibility with X/Ed2559.  Prior to
1.2.3, this API had a sharp edge where it was possible to construct unreduced
scalars, then perform certain operations on them, and compute incorrect
results.  This was fixed in 1.2.3; I don't believe it affected any actually
existing code.